### PR TITLE
Prepare role for archiving

### DIFF
--- a/DISCONTINUATION_NOTICE.md
+++ b/DISCONTINUATION_NOTICE.md
@@ -1,0 +1,7 @@
+Note: Development and maintenance of this software has stopped.
+
+Its functional scope is covered and expanded by Ansible Collection [sap_install](https://github.com/sap-linuxlab/community.sap_install) and transferred to
+the GitHub organization [sap-linuxlab](https://github.com/sap-linuxlab) as a joint initiative by SAP Technology Partners. The collection can be found in
+the following GitHub repository: [https://github.com/sap-linuxlab/community.sap_install](https://github.com/sap-linuxlab/community.sap_install)
+
+Use role [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure) to configure a system for the installation of SAP software.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# **NOTE:** Development and maintenance of this software has stopped.
+For more information, see [DISCONTINUATION_NOTICE.md](DISCONTINUATION_NOTICE.md).
+***
+
 Role Name: sap-base-settings
 ============================
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # **NOTE:** Development and maintenance of this software has stopped.
+The successor role is [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure).
+
 For more information, see [DISCONTINUATION_NOTICE.md](DISCONTINUATION_NOTICE.md).
 ***
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
       ""
       "*** NOTE: This role is deprecated. ***"
       ""
-      "Role sap_general_preconfigure, when run in assert mode, provides all the features of this role, and more."
+      "Role sap_general_preconfigure provides all the features of this role, and more."
       "You can find the role in repository https://www.github.com/sap-linuxlab/community.sap_install ."
       ""
       "Press RETURN to continue anyway, or <ctrl>c, a, to abort:"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,16 @@
 ---
 
+- name: Print deprecation notice
+  pause:
+    prompt: |
+      ""
+      "*** NOTE: This role is deprecated. ***"
+      ""
+      "Role sap_general_preconfigure, when run in assert mode, provides all the features of this role, and more."
+      "You can find the role in repository https://www.github.com/sap-linuxlab/community.sap_install ."
+      ""
+      "Press RETURN to continue anyway, or <ctrl>c, a, to abort:"
+
 #- name: include os specific vars
   #include_vars: '{{ item }}'
   #with_first_found:


### PR DESCRIPTION
We want to discontinue development and maintenance of this role.

Its functional scope is covered and expanded by Ansible Collection [sap_install](https://github.com/sap-linuxlab/community.sap_install) and transferred to the GitHub organization [sap-linuxlab](https://github.com/sap-linuxlab) as a joint initiative by SAP Technology Partners. The collection can be found in the following GitHub repository: [https://github.com/sap-linuxlab/community.sap_install](https://github.com/sap-linuxlab/community.sap_install)

Use role [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure) to configure a system for the installation of SAP software.